### PR TITLE
Fix trending up icon export in dashboard view

### DIFF
--- a/marketplace-analytics/frontend/src/views/DashboardView.vue
+++ b/marketplace-analytics/frontend/src/views/DashboardView.vue
@@ -72,7 +72,7 @@
           :value="analytics.totalProfit"
           format="currency"
           color="green"
-          :icon="TrendingUpIcon"
+          :icon="ArrowTrendingUpIcon"
           description="После всех комиссий"
         />
         
@@ -206,7 +206,7 @@ import LineChart from '@/components/charts/LineChart.vue'
 import PieChart from '@/components/charts/PieChart.vue'
 import {
   CurrencyDollarIcon,
-  TrendingUpIcon,
+  ArrowTrendingUpIcon,
   ChartBarIcon,
   ShoppingBagIcon,
   CloudArrowUpIcon,


### PR DESCRIPTION
Replace `TrendingUpIcon` with `ArrowTrendingUpIcon` to fix a Vue Router import error.

The `TrendingUpIcon` was causing a `SyntaxError` because it does not exist in the Heroicons package. The correct icon name is `ArrowTrendingUpIcon`.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfe7bc9c-37aa-40a0-84fb-19308eccd8bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dfe7bc9c-37aa-40a0-84fb-19308eccd8bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

