### PR TITLE
Fix analytics network error

### DIFF
--- a/marketplace-analytics/frontend/.env
+++ b/marketplace-analytics/frontend/.env
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:3000/api
+VITE_API_BASE_URL=http://localhost:3001/api


### PR DESCRIPTION
Update frontend API base URL to port 3001 to connect to the backend server.

The backend server was unable to start on its default port 3000 due to an `EADDRINUSE` error. To resolve this, the backend was configured to run on port 3001, requiring this frontend configuration update.

---
<a href="https://cursor.com/background-agent?bcId=bc-097a21aa-7b42-487f-a693-5cb8c561a741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-097a21aa-7b42-487f-a693-5cb8c561a741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

